### PR TITLE
fix(style): Remove bookmark-bar z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -123,9 +123,9 @@
 /* styles will be broken for other panel position */
 
 /* uncomment this to not show side panel when minimised */
-#panels-container.icons {
-    display: none
-}
+/* #panels-container.icons { */
+/*     display: none */
+/* } */
 
 #panels-container {
     background: none;
@@ -181,7 +181,6 @@
 
 .bookmark-bar .observer button{
     background: var(--colorBgIntense);
-    z-index: 999;
 }
 
 .bookmark-bar .observer button {


### PR DESCRIPTION
also actually comments out the panels-container display none.

the z-index was causing the bookmark bar to show above the address bar results